### PR TITLE
Rename project to blogwatcher-cli

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/JulienTant/blogwatcher-cli-cli/internal/version.Version={{.Version}}
+      - -s -w -X github.com/JulienTant/blogwatcher-cli/internal/version.Version={{.Version}}
 
 archives:
   - id: blogwatcher-cli
@@ -38,7 +38,7 @@ changelog:
 # brews:
 #   - name: blogwatcher-cli
 #     description: "Track blog articles and detect new posts."
-#     homepage: "https://github.com/JulienTant/blogwatcher-cli-cli"
+#     homepage: "https://github.com/JulienTant/blogwatcher-cli"
 #     license: "MIT"
 #     repository:
 #       owner: JulienTant

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,11 @@
 version: 2
 
-project_name: blogwatcher
+project_name: blogwatcher-cli
 
 builds:
-  - id: blogwatcher
-    main: ./cmd/blogwatcher
-    binary: blogwatcher
+  - id: blogwatcher-cli
+    main: ./cmd/blogwatcher-cli
+    binary: blogwatcher-cli
     env:
       - CGO_ENABLED=1
     goos:
@@ -13,12 +13,12 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/JulienTant/blogwatcher/internal/version.Version={{.Version}}
+      - -s -w -X github.com/JulienTant/blogwatcher-cli-cli/internal/version.Version={{.Version}}
 
 archives:
-  - id: blogwatcher
+  - id: blogwatcher-cli
     builds:
-      - blogwatcher
+      - blogwatcher-cli
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format: tar.gz
     format_overrides:
@@ -36,15 +36,15 @@ changelog:
       - '^test:'
 
 # brews:
-#   - name: blogwatcher
+#   - name: blogwatcher-cli
 #     description: "Track blog articles and detect new posts."
-#     homepage: "https://github.com/JulienTant/blogwatcher"
+#     homepage: "https://github.com/JulienTant/blogwatcher-cli-cli"
 #     license: "MIT"
 #     repository:
 #       owner: JulienTant
 #       name: homebrew-tap
 #       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 #     install: |
-#       bin.install "blogwatcher"
+#       bin.install "blogwatcher-cli"
 #     test: |
-#       system "#{bin}/blogwatcher", "--version"
+#       system "#{bin}/blogwatcher-cli", "--version"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlogWatcher
 
-Fork of [Hyaxia/blogwatcher](https://github.com/Hyaxia/blogwatcher).
+Fork of [Hyaxia/blogwatcher-cli](https://github.com/Hyaxia/blogwatcher-cli).
 
 A Go CLI tool to track blog articles, detect new posts, and manage read/unread status. Supports both RSS/Atom feeds and HTML scraping as fallback.
 
@@ -17,13 +17,13 @@ A Go CLI tool to track blog articles, detect new posts, and manage read/unread s
 
 ```bash
 # Homebrew (Linux)
-brew install JulienTant/tap/blogwatcher
+brew install JulienTant/tap/blogwatcher-cli
 
 # Install the CLI
-go install github.com/JulienTant/blogwatcher/cmd/blogwatcher@latest
+go install github.com/JulienTant/blogwatcher-cli-cli/cmd/blogwatcher-cli@latest
 
 # Or build locally
-go build ./cmd/blogwatcher
+go build ./cmd/blogwatcher-cli
 ```
 
 Windows and Linux binaries are also available on the GitHub Releases page.
@@ -34,65 +34,65 @@ Windows and Linux binaries are also available on the GitHub Releases page.
 
 ```bash
 # Add a blog (auto-discovers RSS feed)
-blogwatcher add "My Favorite Blog" https://example.com/blog
+blogwatcher-cli add "My Favorite Blog" https://example.com/blog
 
 # Add with explicit feed URL
-blogwatcher add "Tech Blog" https://techblog.com --feed-url https://techblog.com/rss.xml
+blogwatcher-cli add "Tech Blog" https://techblog.com --feed-url https://techblog.com/rss.xml
 
 # Add with HTML scraping selector (for blogs without feeds)
-blogwatcher add "No-RSS Blog" https://norss.com --scrape-selector "article h2 a"
+blogwatcher-cli add "No-RSS Blog" https://norss.com --scrape-selector "article h2 a"
 ```
 
 ### Managing Blogs
 
 ```bash
 # List all tracked blogs
-blogwatcher blogs
+blogwatcher-cli blogs
 
 # Remove a blog (and all its articles)
-blogwatcher remove "My Favorite Blog"
+blogwatcher-cli remove "My Favorite Blog"
 
 # Remove without confirmation
-blogwatcher remove "My Favorite Blog" -y
+blogwatcher-cli remove "My Favorite Blog" -y
 ```
 
 ### Scanning for New Articles
 
 ```bash
 # Scan all blogs for new articles
-blogwatcher scan
+blogwatcher-cli scan
 
 # Scan a specific blog
-blogwatcher scan "Tech Blog"
+blogwatcher-cli scan "Tech Blog"
 ```
 
 ### Viewing Articles
 
 ```bash
 # List unread articles
-blogwatcher articles
+blogwatcher-cli articles
 
 # List all articles (including read)
-blogwatcher articles --all
+blogwatcher-cli articles --all
 
 # List articles from a specific blog
-blogwatcher articles --blog "Tech Blog"
+blogwatcher-cli articles --blog "Tech Blog"
 ```
 
 ### Managing Read Status
 
 ```bash
 # Mark an article as read (use article ID from articles list)
-blogwatcher read 42
+blogwatcher-cli read 42
 
 # Mark an article as unread
-blogwatcher unread 42
+blogwatcher-cli unread 42
 
 # Mark all unread articles as read
-blogwatcher read-all
+blogwatcher-cli read-all
 
 # Mark all unread articles as read for a blog (skip prompt)
-blogwatcher read-all --blog "Tech Blog" --yes
+blogwatcher-cli read-all --blog "Tech Blog" --yes
 ```
 
 ## How It Works
@@ -125,7 +125,7 @@ When RSS isn't available, provide a CSS selector that matches article links:
 
 ## Database
 
-BlogWatcher stores data in SQLite at `~/.blogwatcher/blogwatcher.db`:
+BlogWatcher stores data in SQLite at `~/.blogwatcher-cli/blogwatcher-cli.db`:
 
 -   **blogs** - Tracked blogs (name, URL, feed URL, scrape selector)
 -   **articles** - Discovered articles (title, URL, dates, read status)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlogWatcher
 
-Fork of [Hyaxia/blogwatcher-cli](https://github.com/Hyaxia/blogwatcher-cli).
+Fork of [Hyaxia/blogwatcher](https://github.com/Hyaxia/blogwatcher).
 
 A Go CLI tool to track blog articles, detect new posts, and manage read/unread status. Supports both RSS/Atom feeds and HTML scraping as fallback.
 
@@ -20,7 +20,7 @@ A Go CLI tool to track blog articles, detect new posts, and manage read/unread s
 brew install JulienTant/tap/blogwatcher-cli
 
 # Install the CLI
-go install github.com/JulienTant/blogwatcher-cli-cli/cmd/blogwatcher-cli@latest
+go install github.com/JulienTant/blogwatcher-cli/cmd/blogwatcher-cli@latest
 
 # Or build locally
 go build ./cmd/blogwatcher-cli
@@ -125,7 +125,15 @@ When RSS isn't available, provide a CSS selector that matches article links:
 
 ## Database
 
-BlogWatcher stores data in SQLite at `~/.blogwatcher-cli/blogwatcher-cli.db`:
+BlogWatcher stores data in SQLite at `~/.blogwatcher-cli/blogwatcher-cli.db`.
+
+If upgrading from the original `blogwatcher`, migrate your existing database:
+
+```bash
+mv ~/.blogwatcher/blogwatcher.db ~/.blogwatcher-cli/blogwatcher-cli.db
+```
+
+Tables:
 
 -   **blogs** - Tracked blogs (name, URL, feed URL, scrape selector)
 -   **articles** - Discovered articles (title, URL, dates, read status)

--- a/cmd/blogwatcher-cli/main.go
+++ b/cmd/blogwatcher-cli/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/JulienTant/blogwatcher-cli/internal/cli"
+
+func main() {
+	cli.Execute()
+}

--- a/cmd/blogwatcher/main.go
+++ b/cmd/blogwatcher/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/JulienTant/blogwatcher/internal/cli"
-
-func main() {
-	cli.Execute()
-}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/JulienTant/blogwatcher
+module github.com/JulienTant/blogwatcher-cli
 
 go 1.24.0
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -12,10 +12,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/JulienTant/blogwatcher/internal/controller"
-	"github.com/JulienTant/blogwatcher/internal/model"
-	"github.com/JulienTant/blogwatcher/internal/scanner"
-	"github.com/JulienTant/blogwatcher/internal/storage"
+	"github.com/JulienTant/blogwatcher-cli/internal/controller"
+	"github.com/JulienTant/blogwatcher-cli/internal/model"
+	"github.com/JulienTant/blogwatcher-cli/internal/scanner"
+	"github.com/JulienTant/blogwatcher-cli/internal/storage"
 )
 
 func newAddCommand() *cobra.Command {
@@ -93,7 +93,7 @@ func newBlogsCommand() *cobra.Command {
 				return err
 			}
 			if len(blogs) == 0 {
-				fmt.Println("No blogs tracked yet. Use 'blogwatcher add' to add one.")
+				fmt.Println("No blogs tracked yet. Use 'blogwatcher-cli add' to add one.")
 				return nil
 			}
 			color.New(color.FgCyan, color.Bold).Printf("Tracked blogs (%d):\n\n", len(blogs))
@@ -151,7 +151,7 @@ func newScanCommand() *cobra.Command {
 					return err
 				}
 				if len(blogs) == 0 {
-					fmt.Println("No blogs tracked yet. Use 'blogwatcher add' to add one.")
+					fmt.Println("No blogs tracked yet. Use 'blogwatcher-cli add' to add one.")
 					return nil
 				}
 				if !silent {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,14 +5,14 @@ import (
 	"os"
 	"strings"
 
-	"github.com/JulienTant/blogwatcher/internal/version"
+	"github.com/JulienTant/blogwatcher-cli/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 func NewRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:           "blogwatcher",
+		Use:           "blogwatcher-cli",
 		Short:         "BlogWatcher - Track blog articles and detect new posts.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -23,7 +23,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.Version = version.Version
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 
-	rootCmd.PersistentFlags().String("db", "", "Path to the SQLite database file (default: ~/.blogwatcher/blogwatcher.db)")
+	rootCmd.PersistentFlags().String("db", "", "Path to the SQLite database file (default: ~/.blogwatcher-cli/blogwatcher-cli.db)")
 
 	rootCmd.AddCommand(newAddCommand())
 	rootCmd.AddCommand(newRemoveCommand())

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -3,8 +3,8 @@ package controller
 import (
 	"fmt"
 
-	"github.com/JulienTant/blogwatcher/internal/model"
-	"github.com/JulienTant/blogwatcher/internal/storage"
+	"github.com/JulienTant/blogwatcher-cli/internal/model"
+	"github.com/JulienTant/blogwatcher-cli/internal/storage"
 )
 
 type BlogNotFoundError struct {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -4,8 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/JulienTant/blogwatcher/internal/model"
-	"github.com/JulienTant/blogwatcher/internal/storage"
+	"github.com/JulienTant/blogwatcher-cli/internal/model"
+	"github.com/JulienTant/blogwatcher-cli/internal/storage"
 )
 
 func TestAddBlogAndRemoveBlog(t *testing.T) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/JulienTant/blogwatcher/internal/model"
-	"github.com/JulienTant/blogwatcher/internal/rss"
-	"github.com/JulienTant/blogwatcher/internal/scraper"
-	"github.com/JulienTant/blogwatcher/internal/storage"
+	"github.com/JulienTant/blogwatcher-cli/internal/model"
+	"github.com/JulienTant/blogwatcher-cli/internal/rss"
+	"github.com/JulienTant/blogwatcher-cli/internal/scraper"
+	"github.com/JulienTant/blogwatcher-cli/internal/storage"
 )
 
 type ScanResult struct {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/JulienTant/blogwatcher/internal/model"
-	"github.com/JulienTant/blogwatcher/internal/storage"
+	"github.com/JulienTant/blogwatcher-cli/internal/model"
+	"github.com/JulienTant/blogwatcher-cli/internal/storage"
 )
 
 const sampleFeed = `<?xml version="1.0" encoding="UTF-8" ?>

--- a/internal/storage/database.go
+++ b/internal/storage/database.go
@@ -11,7 +11,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/JulienTant/blogwatcher/internal/model"
+	"github.com/JulienTant/blogwatcher-cli/internal/model"
 )
 
 const sqliteTimeLayout = time.RFC3339Nano
@@ -21,7 +21,7 @@ func DefaultDBPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".blogwatcher", "blogwatcher.db"), nil
+	return filepath.Join(home, ".blogwatcher-cli", "blogwatcher-cli.db"), nil
 }
 
 type Database struct {

--- a/internal/storage/database_test.go
+++ b/internal/storage/database_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/JulienTant/blogwatcher/internal/model"
+	"github.com/JulienTant/blogwatcher-cli/internal/model"
 )
 
 func TestDatabaseCreatesFileAndCRUD(t *testing.T) {


### PR DESCRIPTION
## Summary
- Rename Go module from `github.com/JulienTant/blogwatcher` to `github.com/JulienTant/blogwatcher-cli`
- Rename binary from `blogwatcher` to `blogwatcher-cli` (`cmd/blogwatcher/` -> `cmd/blogwatcher-cli/`)
- Update default DB path to `~/.blogwatcher-cli/blogwatcher-cli.db`
- Update goreleaser project/build/binary names
- Update README and CLI help text

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed CLI from `blogwatcher` to `blogwatcher-cli` (binary, commands, and install/build targets).
  * Updated default database path to `~/.blogwatcher-cli/blogwatcher-cli.db`.

* **Documentation**
  * Updated install and usage examples (including Homebrew) to `blogwatcher-cli`.
  * Added upgrade/migration instructions to move the old database to the new location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->