### PR TITLE
Fix RSS discovery for direct feed URLs and rel=self links

### DIFF
--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -89,6 +90,16 @@ func DiscoverFeedURL(ctx context.Context, blogURL string, timeout time.Duration)
 		return "", nil
 	}
 
+	// If the URL already returns a feed content-type, return it directly.
+	contentType := response.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err == nil {
+		// Only accept explicit feed types, not generic XML (to avoid sitemap false positives).
+		if mediaType == "application/rss+xml" || mediaType == "application/atom+xml" || mediaType == "application/feed+json" {
+			return blogURL, nil
+		}
+	}
+
 	base, err := url.Parse(blogURL)
 	if err != nil {
 		return "", nil
@@ -109,6 +120,10 @@ func DiscoverFeedURL(ctx context.Context, blogURL string, timeout time.Duration)
 
 	for _, feedType := range feedTypes {
 		selection := doc.Find(fmt.Sprintf("link[rel='alternate'][type='%s']", feedType)).First()
+		if selection.Length() == 0 {
+			// Also check rel="self" for feeds that use self-referencing links.
+			selection = doc.Find(fmt.Sprintf("link[rel='self'][type='%s']", feedType)).First()
+		}
 		if selection.Length() == 0 {
 			continue
 		}

--- a/internal/rss/rss_test.go
+++ b/internal/rss/rss_test.go
@@ -62,3 +62,45 @@ func TestDiscoverFeedURL(t *testing.T) {
 	require.NoError(t, err, "discover feed")
 	require.NotEmpty(t, feedURL, "expected feed url")
 }
+
+func TestDiscoverFeedURL_XMLContentType(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tag/AI/feed/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml; charset=UTF-8")
+		_, writeErr := w.Write([]byte(sampleFeed))
+		if writeErr != nil {
+			http.Error(w, writeErr.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	feedURL, err := DiscoverFeedURL(context.Background(), server.URL+"/tag/AI/feed/", 2*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, server.URL+"/tag/AI/feed/", feedURL, "should return URL directly for feed content-type")
+}
+
+func TestDiscoverFeedURL_RelSelf(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, writeErr := w.Write([]byte(`<html><head><link rel="self" type="application/rss+xml" href="/my-feed.xml" /></head></html>`))
+		if writeErr != nil {
+			http.Error(w, writeErr.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+	mux.HandleFunc("/my-feed.xml", func(w http.ResponseWriter, r *http.Request) {
+		_, writeErr := w.Write([]byte(sampleFeed))
+		if writeErr != nil {
+			http.Error(w, writeErr.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	feedURL, err := DiscoverFeedURL(context.Background(), server.URL, 2*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, server.URL+"/my-feed.xml", feedURL, "should discover feed from rel=self link")
+}


### PR DESCRIPTION
## Summary

- When a URL already returns a feed content-type (`application/rss+xml`, `application/atom+xml`, `application/feed+json`), `DiscoverFeedURL` now returns it directly instead of trying to parse HTML
- Added fallback to check `rel="self"` link tags in addition to `rel="alternate"`, since some feeds (e.g. TechCrunch tag feeds) use self-referencing links
- Added two new unit tests covering both cases

## Credit

Based on upstream [Hyaxia/blogwatcher#14](https://github.com/Hyaxia/blogwatcher/pull/14) by [@carlotran4](https://github.com/carlotran4), adapted to our fork's patterns (context threading, testify, error handling in tests, etc.).

## Test plan

- [x] `TestDiscoverFeedURL_XMLContentType` - verifies direct feed URL return for RSS content-type
- [x] `TestDiscoverFeedURL_RelSelf` - verifies discovery via `rel="self"` link tags
- [x] Full test suite passes (24 tests)
- [x] `golangci-lint run` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved RSS feed discovery with Content-Type header inspection and additional feed link pattern support for more reliable feed identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->