### PR TITLE
Prepare v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,14 @@ jobs:
 
       - name: Run GoReleaser (release)
         if: startsWith(github.ref, 'refs/tags/')
-        run: goreleaser release --clean
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          NOTES="docs/release-notes/${TAG}.md"
+          if [ -f "$NOTES" ]; then
+            goreleaser release --clean --release-notes "$NOTES"
+          else
+            goreleaser release --clean
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,11 +34,11 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
+  disable: true
+
+release:
+  header: |
+    See [release notes](https://github.com/JulienTant/blogwatcher-cli/blob/main/docs/release-notes/{{ .Tag }}.md) for details.
 
 snapshot:
   version_template: "main"

--- a/docs/release-note-template.md
+++ b/docs/release-note-template.md
@@ -1,0 +1,46 @@
+# Release Notes Template
+
+Use this template when creating a new GitHub release.
+
+---
+
+## vX.Y.Z
+
+### New
+
+- 
+
+### Improved
+
+- 
+
+### Fixed
+
+- 
+
+### Breaking
+
+- 
+
+### Internal
+
+- 
+
+---
+
+### Section guide
+
+| Section | What goes here |
+|---|---|
+| **New** | New commands, flags, features users can use |
+| **Improved** | Enhancements to existing behavior (performance, UX, output) |
+| **Fixed** | Bug fixes |
+| **Breaking** | Changes that require user action (flag renames, config changes, migration) |
+| **Internal** | Dependency updates, refactors, CI changes (keep brief, users mostly skip this) |
+
+### Tips
+
+- Lead each bullet with what changed, not how. "Add `import` command for OPML files" not "Added internal/opml package".
+- Link PRs: `Add category filtering (#12)`.
+- Omit empty sections.
+- Keep it scannable -- one line per change, no paragraphs.

--- a/docs/release-notes/v0.1.0.md
+++ b/docs/release-notes/v0.1.0.md
@@ -1,0 +1,46 @@
+## v0.1.0
+
+First major release of the blogwatcher-cli fork. Renamed from blogwatcher, with new features, security hardening, and proper testing infrastructure.
+
+### New
+
+- Add `import` command for bulk-importing blogs from OPML files (Feedly, Inoreader, NewsBlur exports) (#11)
+- Add `--category` / `-c` flag to filter articles by RSS/Atom category (#12)
+- Add SSRF-safe HTTP client — blocks requests to private IPs, loopback, link-local, and cloud metadata endpoints (#9)
+- Add `--unsafe-client` flag to disable SSRF protection for local development (#9)
+- Add environment variable support — all flags configurable via `BLOGWATCHER_` prefix (#1)
+- Add `--db` flag / `BLOGWATCHER_DB` to customize database path (#1)
+- Add Docker image published to GHCR (#4)
+
+### Improved
+
+- RSS feed discovery now detects feeds served with RSS/Atom content-type headers directly (#10)
+- RSS feed discovery checks `rel="self"` link tags in addition to `rel="alternate"` (#10)
+- Article categories from RSS/Atom feeds are parsed, stored, and displayed (#12)
+- Category filtering is case-insensitive (#12)
+- Scanner errors are now hard failures instead of silent soft errors (#9)
+- Discovered feed URLs are only persisted after successful parse (#12)
+- Scanner worker pool uses `errgroup` to prevent deadlocks on error (#9)
+- All functions accept `context.Context` for proper cancellation and timeout support (#7)
+
+### Internal
+
+- Rename project from blogwatcher to blogwatcher-cli (#2)
+- Switch to squirrel query builder — no raw SQL in Go code (#8)
+- Add golang-migrate with embedded `.sql` migration files (#8)
+- Refactor `rss.Fetcher` and `scraper.Scraper` as structs with injected `*http.Client` (#9)
+- Add comprehensive e2e test suite with real RSS/Atom/HTML fixtures (#7)
+- Add `.golangci.yml` with explicit linter config (errcheck, govet, staticcheck, bodyclose, errorlint, noctx, testifylint) (#7)
+- Switch CI and release workflows to mise as single source of truth for tool versions (#7)
+- Add gotestsum for test output (#7)
+- Add PR template (#7)
+- Upgrade to Go 1.26.1 with proper error handling and testify throughout (#3)
+
+### Contributors
+
+- [@JulienTant](https://github.com/JulienTant)
+- [@Hyaxia](https://github.com/Hyaxia) — original blogwatcher author
+- [@carlotran4](https://github.com/carlotran4) — RSS discovery improvements (#10)
+- [@mihajlo-jovanovic](https://github.com/mihajlo-jovanovic) — SSRF protection inspiration (#9)
+- [@pastukhov](https://github.com/pastukhov) — OPML import (#11)
+- [@weronikakombat](https://github.com/weronikakombat) — category support (#12)

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -35,6 +35,8 @@ Track blog and RSS/Atom feed updates with the `blogwatcher-cli` tool. Supports a
 - Mark all articles read: `blogwatcher-cli read-all`
 - Mark all read for a blog: `blogwatcher-cli read-all --blog "My Blog" --yes`
 - Remove a blog: `blogwatcher-cli remove "My Blog" --yes`
+- Import blogs from OPML: `blogwatcher-cli import subscriptions.opml`
+- Filter by category: `blogwatcher-cli articles --category "Engineering"`
 
 ## Environment variables
 
@@ -44,6 +46,7 @@ All flags can be set via environment variables with the `BLOGWATCHER_` prefix:
 - `BLOGWATCHER_WORKERS` - Number of concurrent scan workers (default: 8)
 - `BLOGWATCHER_SILENT` - Only output "scan done" when scanning
 - `BLOGWATCHER_YES` - Skip confirmation prompts
+- `BLOGWATCHER_CATEGORY` - Filter articles by category
 
 ## Example output
 
@@ -75,15 +78,19 @@ Unread articles (2):
        Blog: xkcd
        URL: https://xkcd.com/3095/
        Published: 2026-04-02
+       Categories: Comics, Science
 
   [2] [new] Volcano Fact
        Blog: xkcd
        URL: https://xkcd.com/3094/
        Published: 2026-04-01
+       Categories: Comics
 ```
 
 ## Notes
 
+- Import blogs in bulk from OPML files exported by Feedly, Inoreader, NewsBlur, etc.
+- Categories from RSS/Atom feeds are stored and can be used to filter articles.
 - blogwatcher-cli auto-discovers RSS/Atom feeds from blog homepages when no `--feed-url` is provided.
 - If RSS fails and `--scrape-selector` is configured, it falls back to HTML scraping.
 - Database is stored at `~/.blogwatcher-cli/blogwatcher-cli.db` by default (override with `--db` or `BLOGWATCHER_DB`).


### PR DESCRIPTION
## Summary
- Update SKILL.md with `import` command, `--category` flag, categories in output
- Add release note template at `docs/release-note-template.md`
- Add v0.1.0 release notes at `docs/release-notes/v0.1.0.md`
- Configure goreleaser to use handwritten notes from `docs/release-notes/<tag>.md`

## After merge
```bash
git tag v0.1.0
git push origin v0.1.0
```

## Test plan
- [x] `golangci-lint run` passes
- [x] `gotestsum -- ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)