### PR TITLE
Remove version from release artifact names

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ archives:
   - id: blogwatcher-cli
     ids:
       - blogwatcher-cli
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - tar.gz
     format_overrides:

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -13,7 +13,11 @@ Track blog and RSS/Atom feed updates with the `blogwatcher-cli` tool. Supports a
 
 - Go: `go install github.com/JulienTant/blogwatcher-cli/cmd/blogwatcher-cli@latest`
 - Docker: `docker run --rm -v blogwatcher-cli:/data ghcr.io/julientant/blogwatcher-cli`
-- Binaries: [GitHub Releases](https://github.com/JulienTant/blogwatcher-cli/releases)
+- Binary (Linux amd64): `curl -sL https://github.com/JulienTant/blogwatcher-cli/releases/latest/download/blogwatcher-cli_linux_amd64.tar.gz | tar xz -C /usr/local/bin blogwatcher-cli`
+- Binary (Linux arm64): `curl -sL https://github.com/JulienTant/blogwatcher-cli/releases/latest/download/blogwatcher-cli_linux_arm64.tar.gz | tar xz -C /usr/local/bin blogwatcher-cli`
+- Binary (macOS Apple Silicon): `curl -sL https://github.com/JulienTant/blogwatcher-cli/releases/latest/download/blogwatcher-cli_darwin_arm64.tar.gz | tar xz -C /usr/local/bin blogwatcher-cli`
+- Binary (macOS Intel): `curl -sL https://github.com/JulienTant/blogwatcher-cli/releases/latest/download/blogwatcher-cli_darwin_amd64.tar.gz | tar xz -C /usr/local/bin blogwatcher-cli`
+- All binaries: [GitHub Releases](https://github.com/JulienTant/blogwatcher-cli/releases)
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- Removes version number from goreleaser archive `name_template` so GitHub latest release URLs are stable
- Adds direct `curl` download instructions to skill file for all platforms

Stable URLs like `https://github.com/JulienTant/blogwatcher-cli/releases/latest/download/blogwatcher-cli_linux_amd64.tar.gz` now work across releases.

## Test plan
- [ ] Create a release and verify artifact names no longer include version
- [ ] Verify latest release download URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced installation guides with explicit platform-specific commands for Linux (amd64, arm64) and macOS (Intel and Apple Silicon).

* **Chores**
  * Updated build artifact naming configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->