### PR TITLE
Add URL validation to AddBlog function

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/JulienTant/blogwatcher-cli/internal/model"
@@ -37,21 +38,49 @@ func (e ArticleNotFoundError) Error() string {
 	return fmt.Sprintf("Article %d not found", e.ID)
 }
 
-func AddBlog(ctx context.Context, db *storage.Database, name string, url string, feedURL string, scrapeSelector string) (model.Blog, error) {
+type InvalidURLError struct {
+	URL string
+}
+
+func (e InvalidURLError) Error() string {
+	return fmt.Sprintf("Invalid URL: %s", e.URL)
+}
+
+func AddBlog(ctx context.Context, db *storage.Database, name string, urlStr string, feedURL string, scrapeSelector string) (model.Blog, error) {
+	// Validate blog URL
+	if _, err := url.ParseRequestURI(urlStr); err != nil {
+		return model.Blog{}, InvalidURLError{URL: urlStr}
+	}
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+		return model.Blog{}, InvalidURLError{URL: urlStr}
+	}
+
+	// Validate feed URL if provided
+	if feedURL != "" {
+		if _, err := url.ParseRequestURI(feedURL); err != nil {
+			return model.Blog{}, InvalidURLError{URL: feedURL}
+		}
+		parsedFeedURL, err := url.Parse(feedURL)
+		if err != nil || (parsedFeedURL.Scheme != "http" && parsedFeedURL.Scheme != "https") {
+			return model.Blog{}, InvalidURLError{URL: feedURL}
+		}
+	}
+
 	if existing, err := db.GetBlogByName(ctx, name); err != nil {
 		return model.Blog{}, err
 	} else if existing != nil {
 		return model.Blog{}, BlogAlreadyExistsError{Field: "name", Value: name}
 	}
-	if existing, err := db.GetBlogByURL(ctx, url); err != nil {
+	if existing, err := db.GetBlogByURL(ctx, urlStr); err != nil {
 		return model.Blog{}, err
 	} else if existing != nil {
-		return model.Blog{}, BlogAlreadyExistsError{Field: "URL", Value: url}
+		return model.Blog{}, BlogAlreadyExistsError{Field: "URL", Value: urlStr}
 	}
 
 	blog := model.Blog{
 		Name:           name,
-		URL:            url,
+		URL:            urlStr,
 		FeedURL:        feedURL,
 		ScrapeSelector: scrapeSelector,
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -195,7 +195,8 @@ func ImportOPML(ctx context.Context, db *storage.Database, r io.Reader) (added i
 		_, err := AddBlog(ctx, db, title, siteURL, feed.FeedURL, "")
 		if err != nil {
 			var alreadyExists BlogAlreadyExistsError
-			if errors.As(err, &alreadyExists) {
+			var invalidURL InvalidURLError
+			if errors.As(err, &alreadyExists) || errors.As(err, &invalidURL) {
 				skipped++
 				continue
 			}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -28,6 +29,67 @@ func TestAddBlogAndRemoveBlog(t *testing.T) {
 
 	err = RemoveBlog(ctx, db, blog.Name)
 	require.NoError(t, err, "remove blog")
+}
+
+func TestAddBlogInvalidURL(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	testCases := []struct {
+		name    string
+		url     string
+		feedURL string
+	}{
+		{"empty URL", "", ""},
+		{"invalid scheme ftp", "ftp://example.com", ""},
+		{"invalid scheme file", "file:///etc/passwd", ""},
+		{"missing scheme", "example.com", ""},
+		{"invalid URL format", "://invalid-url", ""},
+		{"invalid feed URL", "https://example.com", "ftp://feed.example.com/rss"},
+		{"empty feed URL allowed", "https://example.com", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := AddBlog(ctx, db, "Test"+tc.name, tc.url, tc.feedURL, "")
+			require.Error(t, err, "expected error for invalid URL")
+
+			var invalidURLErr InvalidURLError
+			require.True(t, errors.As(err, &invalidURLErr), "error should be InvalidURLError")
+		})
+	}
+}
+
+func TestAddBlogValidURL(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	testCases := []struct {
+		name    string
+		url     string
+		feedURL string
+	}{
+		{"https URL", "https://example.com", ""},
+		{"http URL", "http://example.com", ""},
+		{"https with feed", "https://example.com", "https://example.com/feed.xml"},
+		{"http with feed", "http://example.com", "http://example.com/rss"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			blogName := "Valid" + tc.name
+			blog, err := AddBlog(ctx, db, blogName, tc.url, tc.feedURL, "")
+			require.NoError(t, err, "expected no error for valid URL")
+			require.Equal(t, tc.url, blog.URL)
+			require.Equal(t, tc.feedURL, blog.FeedURL)
+
+			// Clean up
+			err = RemoveBlog(ctx, db, blogName)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestArticleReadUnread(t *testing.T) {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -47,7 +46,6 @@ func TestAddBlogInvalidURL(t *testing.T) {
 		{"missing scheme", "example.com", ""},
 		{"invalid URL format", "://invalid-url", ""},
 		{"invalid feed URL", "https://example.com", "ftp://feed.example.com/rss"},
-		{"empty feed URL allowed", "https://example.com", ""},
 	}
 
 	for _, tc := range testCases {
@@ -56,7 +54,7 @@ func TestAddBlogInvalidURL(t *testing.T) {
 			require.Error(t, err, "expected error for invalid URL")
 
 			var invalidURLErr InvalidURLError
-			require.True(t, errors.As(err, &invalidURLErr), "error should be InvalidURLError")
+			require.ErrorAs(t, err, &invalidURLErr, "error should be InvalidURLError")
 		})
 	}
 }
@@ -179,6 +177,36 @@ func TestImportOPMLSkipsDuplicates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, added)
 	assert.Equal(t, 1, skipped)
+}
+
+func TestImportOPMLSkipsInvalidURLs(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	// One feed has an unsupported scheme (ftp), one is valid. The bad one
+	// must not halt the import of the good one.
+	opmlData := `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+    <head><title>Subscriptions</title></head>
+    <body>
+        <outline type="rss" text="Bad" title="Bad" xmlUrl="ftp://bad.example.com/feed" htmlUrl="ftp://bad.example.com"/>
+        <outline type="rss" text="Good" title="Good" xmlUrl="http://good.example.com/rss" htmlUrl="http://good.example.com"/>
+    </body>
+</opml>`
+
+	added, skipped, err := ImportOPML(ctx, db, strings.NewReader(opmlData))
+	require.NoError(t, err)
+	assert.Equal(t, 1, added)
+	assert.Equal(t, 1, skipped)
+
+	good, err := db.GetBlogByName(ctx, "Good")
+	require.NoError(t, err)
+	require.NotNil(t, good, "valid feed should still be imported after an invalid one")
+
+	bad, err := db.GetBlogByName(ctx, "Bad")
+	require.NoError(t, err)
+	assert.Nil(t, bad, "invalid feed should not be persisted")
 }
 
 func TestImportOPMLFallbackSiteURL(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds URL validation to prevent invalid URLs from being stored in the database, which could cause failures during scanning.

## Changes

- Added new  type for validation errors
- Validate blog URL format using  and 
- Enforce http/https scheme for both blog URL and optional feed URL
- Added comprehensive test cases for valid and invalid URLs

## Validation Rules

- URLs must have valid format (parsable by Go's url.Parse)
- URLs must use http or https scheme (no ftp://, file://, etc.)
- Empty URLs are rejected
- Feed URL is validated only if provided (empty string is allowed)

## Test Coverage

Added two new test functions:
- : Tests rejection of empty URLs, non-http/https schemes, missing schemes, malformed URLs, and invalid feed URLs
- : Tests acceptance of http:// and https:// URLs with and without feed URLs

## Fixes

Resolves the security concern where invalid URLs could be stored, causing potential failures during the scanning process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger URL validation when adding blogs: only HTTP/HTTPS addresses are accepted for primary and feed URLs; invalid entries are rejected with clear feedback.
  * OPML import now skips invalid URLs instead of failing, reporting added vs skipped entries.

* **Tests**
  * Added tests covering valid/invalid URL scenarios and OPML import skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->