### PR TITLE
Reject URLs with empty host, consolidate validation

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -407,6 +407,35 @@ func TestE2E(t *testing.T) {
 	}
 }
 
+func TestAddBlogInvalidURL(t *testing.T) {
+	for _, mode := range []string{"flags", "env"} {
+		t.Run(mode, func(t *testing.T) {
+			c := &cliOpts{
+				mode:   mode,
+				dbPath: filepath.Join(t.TempDir(), "test.db"),
+			}
+
+			cases := []struct {
+				name string
+				url  string
+			}{
+				{"scheme only", "https://"},
+				{"empty host with path", "http:///path"},
+				{"wrong scheme", "ftp://example.com"},
+				{"no scheme", "example.com"},
+			}
+
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					_, stderr := c.fail(t, []string{"add", "blog-" + tc.name, tc.url}, nil)
+					assert.Contains(t, stderr, "Invalid URL",
+						"expected Invalid URL error for %q", tc.url)
+				})
+			}
+		})
+	}
+}
+
 func TestImportOPML(t *testing.T) {
 	baseURL := startTestServer(t)
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -46,24 +46,24 @@ func (e InvalidURLError) Error() string {
 	return fmt.Sprintf("Invalid URL: %s", e.URL)
 }
 
-func AddBlog(ctx context.Context, db *storage.Database, name string, urlStr string, feedURL string, scrapeSelector string) (model.Blog, error) {
-	// Validate blog URL
-	if _, err := url.ParseRequestURI(urlStr); err != nil {
-		return model.Blog{}, InvalidURLError{URL: urlStr}
+// validateHTTPURL returns an InvalidURLError unless s parses as an absolute
+// http or https URL with a non-empty host. A bare scheme like "https://" is
+// rejected because url.Parse accepts it with an empty Host.
+func validateHTTPURL(s string) error {
+	parsed, err := url.Parse(s)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return InvalidURLError{URL: s}
 	}
-	parsedURL, err := url.Parse(urlStr)
-	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
-		return model.Blog{}, InvalidURLError{URL: urlStr}
-	}
+	return nil
+}
 
-	// Validate feed URL if provided
+func AddBlog(ctx context.Context, db *storage.Database, name string, urlStr string, feedURL string, scrapeSelector string) (model.Blog, error) {
+	if err := validateHTTPURL(urlStr); err != nil {
+		return model.Blog{}, err
+	}
 	if feedURL != "" {
-		if _, err := url.ParseRequestURI(feedURL); err != nil {
-			return model.Blog{}, InvalidURLError{URL: feedURL}
-		}
-		parsedFeedURL, err := url.Parse(feedURL)
-		if err != nil || (parsedFeedURL.Scheme != "http" && parsedFeedURL.Scheme != "https") {
-			return model.Blog{}, InvalidURLError{URL: feedURL}
+		if err := validateHTTPURL(feedURL); err != nil {
+			return model.Blog{}, err
 		}
 	}
 

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -45,7 +45,10 @@ func TestAddBlogInvalidURL(t *testing.T) {
 		{"invalid scheme file", "file:///etc/passwd", ""},
 		{"missing scheme", "example.com", ""},
 		{"invalid URL format", "://invalid-url", ""},
+		{"scheme only", "https://", ""},
+		{"empty host with path", "http:///path", ""},
 		{"invalid feed URL", "https://example.com", "ftp://feed.example.com/rss"},
+		{"feed URL scheme only", "https://example.com", "https://"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

Follow-up to #18 — closes a validation gap and cleans up the implementation.

- **Correctness:** `https://` and `http:///path` were accepted because `url.Parse` returns a non-empty `Scheme` with empty `Host`. Adds a `parsed.Host == ""` guard so bare schemes are rejected.
- **Cleanup:** dropped the redundant `url.ParseRequestURI` pre-check (the `Parse` + scheme + host test covers every case in the existing table), and extracted a single `validateHTTPURL` helper used for both the blog URL and the feed URL.

## Test plan

- [x] New unit cases in `TestAddBlogInvalidURL`: `https://`, `http:///path`, feed `https://`.
- [x] New e2e test `TestAddBlogInvalidURL` exercises the `add` command end-to-end in both `flags` and `env` modes with four invalid inputs, asserting `Invalid URL` on stderr.
- [x] `golangci-lint run ./...` — clean.
- [x] `gotestsum ./...` — 106 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)