### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -1,0 +1,17 @@
+## v0.2.0
+
+Tightens input validation around `add` and `import` so invalid URLs can no longer slip into the database.
+
+### New
+
+- Validate blog and feed URLs on `add` — only `http` and `https` URLs with a non-empty host are accepted. Inputs like `ftp://…`, `example.com`, or `https://` are now rejected up front (#18, #19)
+
+### Improved
+
+- `import` (OPML) skips entries with invalid URLs instead of aborting the whole file — partial imports now continue past bad entries (#18)
+- URL validation collapsed into a single helper so the blog URL and feed URL go through the same rules (#19)
+
+### Contributors
+
+- [@sroecker](https://github.com/sroecker) — URL validation (#18)
+- [@JulienTant](https://github.com/JulienTant)


### PR DESCRIPTION
## Summary

- Release notes for v0.2.0 at `docs/release-notes/v0.2.0.md`.
- Covers PRs #18 (URL validation + OPML skip on invalid) and #19 (host gap + consolidation).
- No SKILL.md updates needed — no new commands, flags, or env vars this release.

## After merge

```
git checkout main && git pull
git tag v0.2.0
git push origin v0.2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)