### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/docs/release-notes/v0.2.1.md
+++ b/docs/release-notes/v0.2.1.md
@@ -1,0 +1,21 @@
+## v0.2.1
+
+Adds date-range filters to `articles` and normalizes stored timestamps to UTC so the comparison is correct regardless of feed timezone.
+
+### New
+
+- `articles --since YYYY-MM-DD` (inclusive) and `--before YYYY-MM-DD` (exclusive) filter the list by publication date. Articles without a publication date are excluded when either flag is set. Available as `BLOGWATCHER_SINCE` / `BLOGWATCHER_BEFORE` (#21)
+
+### Improved
+
+- Stored timestamps (`published_date`, `discovered_date`, `last_scanned`) are normalized to UTC at write time so `--since` / `--before` compare correctly across feeds with non-UTC offsets (#23)
+- Reject `--since > --before` with a clear error instead of silently returning an empty list (#23)
+- Surface `--since` / `--before` parse errors through the standard error path, matching the rest of the `articles` command (#23)
+
+### Internal
+
+- Migration `000003` rewrites existing rows to UTC RFC3339 (second precision). Unparseable legacy timestamps are preserved via `COALESCE` instead of being silently dropped (#23)
+
+### Contributors
+
+- [@JulienTant](https://github.com/JulienTant)

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -41,6 +41,7 @@ Track blog and RSS/Atom feed updates with the `blogwatcher-cli` tool. Supports a
 - Remove a blog: `blogwatcher-cli remove "My Blog" --yes`
 - Import blogs from OPML: `blogwatcher-cli import subscriptions.opml`
 - Filter by category: `blogwatcher-cli articles --category "Engineering"`
+- Filter by date: `blogwatcher-cli articles --since 2024-01-01 --before 2024-02-01` (`--since` inclusive, `--before` exclusive, both `YYYY-MM-DD`)
 
 ## Environment variables
 
@@ -51,6 +52,8 @@ All flags can be set via environment variables with the `BLOGWATCHER_` prefix:
 - `BLOGWATCHER_SILENT` - Only output "scan done" when scanning
 - `BLOGWATCHER_YES` - Skip confirmation prompts
 - `BLOGWATCHER_CATEGORY` - Filter articles by category
+- `BLOGWATCHER_SINCE` - Filter articles published on or after `YYYY-MM-DD`
+- `BLOGWATCHER_BEFORE` - Filter articles published before `YYYY-MM-DD`
 
 ## Example output
 


### PR DESCRIPTION
## Summary
Release notes for v0.2.1 covering the date-filter work from #21 and the UTC normalization / UX hardening from #23. Also updates `skills/SKILL.md` with the new `--since` / `--before` flags and `BLOGWATCHER_SINCE` / `BLOGWATCHER_BEFORE` env vars.

## After merge

```
git checkout main && git pull
git tag v0.2.1
git push origin v0.2.1
```