### PR TITLE
Allow configuring the HTTP User-Agent at runtime

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -20,9 +20,25 @@ import (
 	"github.com/JulienTant/blogwatcher-cli/internal/scanner"
 	"github.com/JulienTant/blogwatcher-cli/internal/scraper"
 	"github.com/JulienTant/blogwatcher-cli/internal/storage"
+	"github.com/JulienTant/blogwatcher-cli/internal/version"
 )
 
-const httpTimeout = 30 * time.Second
+const (
+	httpTimeout          = 30 * time.Second
+	defaultUserAgentTmpl = "blogwatcher-cli/%s (+https://github.com/JulienTant/blogwatcher-cli)"
+)
+
+func defaultUserAgent() string {
+	return fmt.Sprintf(defaultUserAgentTmpl, version.Version)
+}
+
+func resolveUserAgent(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("user-agent must not be empty")
+	}
+	return value, nil
+}
 
 func withDatabase(cmd *cobra.Command, fn func(db *storage.Database) error) error {
 	db, err := storage.OpenDatabase(cmd.Context(), viper.GetString("db"))
@@ -142,10 +158,15 @@ func newScanCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silent := viper.GetBool("silent")
 			workers := viper.GetInt("workers")
+			userAgent, err := resolveUserAgent(viper.GetString("user-agent"))
+			if err != nil {
+				printError(err)
+				return markError(err)
+			}
 
 			return withDatabase(cmd, func(db *storage.Database) error {
 				client := newHTTPClient()
-				sc := scanner.NewScanner(rss.NewFetcher(client), scraper.NewScraper(client))
+				sc := scanner.NewScanner(rss.NewFetcher(client, userAgent), scraper.NewScraper(client, userAgent))
 
 				if len(args) == 1 {
 					result, err := sc.ScanBlogByName(cmd.Context(), db, args[0])
@@ -218,6 +239,7 @@ func newScanCommand() *cobra.Command {
 	}
 	cmd.Flags().BoolP("silent", "s", false, "Only output 'scan done' when complete")
 	cmd.Flags().IntP("workers", "w", 8, "Number of concurrent workers when scanning all blogs")
+	cmd.Flags().String("user-agent", defaultUserAgent(), "User-Agent header used for HTTP requests")
 	return cmd
 }
 

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/JulienTant/blogwatcher-cli/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -88,4 +89,27 @@ func TestParseDateRange(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expected YYYY-MM-DD")
 	})
+}
+
+func TestScanCommandUserAgentFlagDefaultsToDefault(t *testing.T) {
+	cmd := newScanCommand()
+
+	flag := cmd.Flags().Lookup("user-agent")
+	require.NotNil(t, flag)
+	assert.Equal(t, "blogwatcher-cli/"+version.Version+" (+https://github.com/JulienTant/blogwatcher-cli)", flag.DefValue)
+	assert.Equal(t, defaultUserAgent(), flag.Value.String())
+}
+
+func TestResolveUserAgentRejectsEmptyValue(t *testing.T) {
+	_, err := resolveUserAgent(" 	 ")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user-agent")
+}
+
+func TestResolveUserAgentTrimsCustomValue(t *testing.T) {
+	got, err := resolveUserAgent("  MyReader/1.0  ")
+
+	require.NoError(t, err)
+	assert.Equal(t, "MyReader/1.0", got)
 }

--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -32,16 +32,26 @@ func (e FeedParseError) Error() string {
 
 // Fetcher fetches and parses RSS/Atom feeds.
 type Fetcher struct {
-	client *http.Client
+	client    *http.Client
+	userAgent string
 }
 
-// NewFetcher creates a Fetcher with the given HTTP client.
-func NewFetcher(client *http.Client) *Fetcher {
-	return &Fetcher{client: client}
+// NewFetcher creates a Fetcher with the given HTTP client and User-Agent.
+func NewFetcher(client *http.Client, userAgent string) *Fetcher {
+	return &Fetcher{client: client, userAgent: userAgent}
+}
+
+func (f *Fetcher) newRequest(ctx context.Context, requestURL string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", f.userAgent)
+	return req, nil
 }
 
 func (f *Fetcher) ParseFeed(ctx context.Context, feedURL string) ([]FeedArticle, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
+	req, err := f.newRequest(ctx, feedURL)
 	if err != nil {
 		return nil, FeedParseError{Message: fmt.Sprintf("failed to create request: %v", err)}
 	}
@@ -83,7 +93,7 @@ func (f *Fetcher) ParseFeed(ctx context.Context, feedURL string) ([]FeedArticle,
 }
 
 func (f *Fetcher) DiscoverFeedURL(ctx context.Context, blogURL string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blogURL, nil)
+	req, err := f.newRequest(ctx, blogURL)
 	if err != nil {
 		return "", fmt.Errorf("discover feed: %w", err)
 	}
@@ -177,7 +187,7 @@ func (f *Fetcher) DiscoverFeedURL(ctx context.Context, blogURL string) (string, 
 }
 
 func (f *Fetcher) isValidFeed(ctx context.Context, feedURL string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
+	req, err := f.newRequest(ctx, feedURL)
 	if err != nil {
 		return false, err
 	}

--- a/internal/rss/rss_test.go
+++ b/internal/rss/rss_test.go
@@ -26,8 +26,10 @@ const sampleFeed = `<?xml version="1.0" encoding="UTF-8" ?>
 </channel>
 </rss>`
 
+const testUserAgent = "test-user-agent"
+
 func newTestFetcher() *Fetcher {
-	return NewFetcher(&http.Client{Timeout: 2 * time.Second})
+	return NewFetcher(&http.Client{Timeout: 2 * time.Second}, testUserAgent)
 }
 
 func TestParseFeed(t *testing.T) {
@@ -43,6 +45,19 @@ func TestParseFeed(t *testing.T) {
 	require.NoError(t, err, "parse feed")
 	require.Len(t, articles, 2)
 	require.NotNil(t, articles[0].PublishedDate)
+}
+
+func TestParseFeedSetsUserAgent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, testUserAgent, r.Header.Get("User-Agent"))
+		if _, writeErr := w.Write([]byte(sampleFeed)); writeErr != nil {
+			http.Error(w, writeErr.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	_, err := newTestFetcher().ParseFeed(context.Background(), server.URL)
+	require.NoError(t, err, "parse feed")
 }
 
 func TestParseFeedWithCategories(t *testing.T) {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -34,7 +34,7 @@ const sampleFeed = `<?xml version="1.0" encoding="UTF-8" ?>
 
 func newTestScanner() *Scanner {
 	client := &http.Client{Timeout: 2 * time.Second}
-	return NewScanner(rss.NewFetcher(client), scraper.NewScraper(client))
+	return NewScanner(rss.NewFetcher(client, "test-user-agent"), scraper.NewScraper(client, "test-user-agent"))
 }
 
 func TestScanBlogRSS(t *testing.T) {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -29,12 +29,13 @@ func (e ScrapeError) Error() string {
 
 // Scraper scrapes HTML pages for article links.
 type Scraper struct {
-	client *http.Client
+	client    *http.Client
+	userAgent string
 }
 
-// NewScraper creates a Scraper with the given HTTP client.
-func NewScraper(client *http.Client) *Scraper {
-	return &Scraper{client: client}
+// NewScraper creates a Scraper with the given HTTP client and User-Agent.
+func NewScraper(client *http.Client, userAgent string) *Scraper {
+	return &Scraper{client: client, userAgent: userAgent}
 }
 
 func (s *Scraper) ScrapeBlog(ctx context.Context, blogURL string, selector string) ([]ScrapedArticle, error) {
@@ -42,6 +43,7 @@ func (s *Scraper) ScrapeBlog(ctx context.Context, blogURL string, selector strin
 	if err != nil {
 		return nil, ScrapeError{Message: fmt.Sprintf("failed to create request: %v", err)}
 	}
+	req.Header.Set("User-Agent", s.userAgent)
 	response, err := s.client.Do(req)
 	if err != nil {
 		return nil, ScrapeError{Message: fmt.Sprintf("failed to fetch page: %v", err)}

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newTestScraper() *Scraper {
-	return NewScraper(&http.Client{Timeout: 2 * time.Second})
+	return NewScraper(&http.Client{Timeout: 2 * time.Second}, "test-user-agent")
 }
 
 func TestScrapeBlog(t *testing.T) {
@@ -25,6 +25,7 @@ func TestScrapeBlog(t *testing.T) {
 </html>`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "test-user-agent", r.Header.Get("User-Agent"))
 		if _, writeErr := w.Write([]byte(html)); writeErr != nil {
 			http.Error(w, writeErr.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Summary

- Add a `scan --user-agent <string>` flag for runtime User-Agent configuration.
- Derive the default User-Agent version from the existing `version.Version` value.
- Pass the selected User-Agent through `rss.NewFetcher` and `scraper.NewScraper`.
- Centralize User-Agent header setup for RSS requests.
- Reject empty or whitespace-only User-Agent values early.
- Add regression coverage for the CLI default and outgoing HTTP headers.

## Motivation

Some servers reject Go's default transport User-Agent (`Go-http-client/1.1`) with HTTP 406. Creator Hooks is one such server: its RSS endpoint responds with 406 to the default Go client, while accepting an explicit neutral User-Agent.

## Implementation details

- The default User-Agent is generated in `internal/cli/commands.go` from `internal/version.Version`, the same value used by `blogwatcher-cli --version` and injected by GoReleaser:

  ```text
  blogwatcher-cli/<version> (+https://github.com/JulienTant/blogwatcher-cli)
  ```

- `scan` exposes the following flag and uses the generated value by default:

  ```bash
  blogwatcher-cli scan "Page Name" --user-agent "MyReader/1.0"
  ```

- Leading and trailing whitespace is removed from custom values.
- Empty or whitespace-only values are rejected before the database is opened or any request is made.
- `rss.Fetcher` and `scraper.Scraper` receive the User-Agent through their constructors.
- RSS request creation and header configuration are centralized in one helper.
- The RSS helper parameter was renamed from `url` to `requestURL` to avoid shadowing the imported `net/url` package.
- Existing call sites and tests were updated for the new constructor contract.
- No repository-local or developer-specific documentation files are added.

## Scope

No new dependencies were added. The change is limited to HTTP client configuration, input validation, tests, and the existing version plumbing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--user-agent` option to the scan command.
  - Scans now use a versioned default User-Agent for HTTP requests.
  - Custom User-Agent values are trimmed and applied to RSS and website requests.

- **Bug Fixes**
  - Blank User-Agent values are rejected before scanning begins.

- **Tests**
  - Added coverage for default, custom, validation, and request-header behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->